### PR TITLE
Add some basic stats for the SULI report

### DIFF
--- a/SLA.R
+++ b/SLA.R
@@ -79,6 +79,29 @@ if(any(sla_joined$Species_code == "")) {
   warning("We blank species codes!")  
 }
 
+
+# ----------- Basic statistics
+
+# We are interested in three things basically: whether SLA varies between
+# species (we would expect yes); whether it varies between "low" and "high" 
+# canopy positions (we would expect yes, but tricky because most of the sampled
+# trees as subcanopy and not in full sunlight); and whether it varies between
+# the "Shore" plot versus all the upland plots.
+
+cat("Overall species effect:\n")
+m_species <- lm(specific_leaf_area ~ Species_code, data = sla_joined)
+print(car::Anova(m_species, type = "III"))
+
+cat("Pairwise t-test comparison between species (adjusting for multiple comparisons):\n")
+pairwise.t.test(sla_joined$specific_leaf_area, sla_joined$Species_code, p.adj = "bonferroni")
+
+cat("Combined effects of species, position, and shore versus upland:\n")
+sla_joined$Shoreplot <- sla_joined$Plot == "Shore"
+m_overall <- lm(specific_leaf_area ~ Species_code + Position + Shoreplot, data = sla_joined)
+print(summary(m_overall))
+print(car::Anova(m_overall, type = "III"))
+
+
 ## SLA by Plot
 sla_by_plot <- sla_joined %>% 
   ggplot(aes(Species_code, specific_leaf_area, color = Position)) +

--- a/SLA.R
+++ b/SLA.R
@@ -93,7 +93,7 @@ m_species <- lm(specific_leaf_area ~ Species_code, data = sla_joined)
 print(car::Anova(m_species, type = "III"))
 
 cat("Pairwise t-test comparison between species (adjusting for multiple comparisons):\n")
-pairwise.t.test(sla_joined$specific_leaf_area, sla_joined$Species_code, p.adj = "bonferroni")
+print(pairwise.t.test(sla_joined$specific_leaf_area, sla_joined$Species_code, p.adj = "bonferroni"))
 
 cat("Combined effects of species, position, and shore versus upland:\n")
 sla_joined$Shoreplot <- sla_joined$Plot == "Shore"


### PR DESCRIPTION
```
Overall species effect:
Anova Table (Type III tests)

Response: specific_leaf_area
             Sum Sq  Df  F value    Pr(>F)    
(Intercept)  916945   1 159.7204 < 2.2e-16 ***
Species_code 313488   7   7.8008  5.83e-08 ***
Residuals    803731 140                       
---
Signif. codes:  0 ‘***’ 0.001 ‘**’ 0.01 ‘*’ 0.05 ‘.’ 0.1 ‘ ’ 1
```
This is the **overall species effect, ignoring all other factors**. It shows that species is _highly_ significant (P = 5.83e-08; normally in a paper we'd just say "P < 0.001")

```
Pairwise t-test comparison between species (adjusting for multiple comparisons):

	Pairwise comparisons using t tests with pooled SD 

data:  sla_joined$specific_leaf_area and sla_joined$Species_code 

     ACRU    CAGL   COFL   FAGR    LIST   LITU   NYSY  
CAGL 0.2701  -      -      -       -      -      -     
COFL 1.0000  1.0000 -      -       -      -      -     
FAGR 1.3e-06 1.0000 1.0000 -       -      -      -     
LIST 1.0000  1.0000 1.0000 5.9e-05 -      -      -     
LITU 0.0253  1.0000 1.0000 1.0000  0.2384 -      -     
NYSY 0.0082  1.0000 1.0000 1.0000  0.1260 1.0000 -     
QUAL 1.0000  0.5325 1.0000 4.2e-05 1.0000 0.0975 0.0508

P value adjustment method: bonferroni 
```
These are P values for **post hoc_ comparisons between species**. For example, they show that red maple is not significant different from hickory (upper left 0.2701), but _is_ very different from beech.
```
Combined effects of species, position, and shore versus upland:

Call:
lm(formula = specific_leaf_area ~ Species_code + Position + Shoreplot, 
    data = sla_joined)

Residuals:
    Min      1Q  Median      3Q     Max 
-250.27  -25.97    0.06   37.74  337.18 

Coefficients:
                  Estimate Std. Error t value Pr(>|t|)    
(Intercept)         176.32      21.35   8.257 1.08e-13 ***
Species_codeCAGL     76.54      33.84   2.262  0.02526 *  
Species_codeCOFL     72.59      54.92   1.322  0.18847    
Species_codeFAGR    115.58      20.36   5.676 7.82e-08 ***
Species_codeLIST     24.69      20.28   1.217  0.22556    
Species_codeLITU     73.45      25.01   2.937  0.00388 ** 
Species_codeNYSY     87.76      21.43   4.096 7.14e-05 ***
Species_codeQUAL     16.71      22.59   0.740  0.46080    
PositionLow/Shade    24.99      15.30   1.634  0.10463    
ShoreplotTRUE       -30.71      14.96  -2.053  0.04194 *  
---
Signif. codes:  0 ‘***’ 0.001 ‘**’ 0.01 ‘*’ 0.05 ‘.’ 0.1 ‘ ’ 1

Residual standard error: 73.89 on 138 degrees of freedom
Multiple R-squared:  0.3257,	Adjusted R-squared:  0.2817 
F-statistic: 7.406 on 9 and 138 DF,  p-value: 8.931e-09

Anova Table (Type III tests)

Response: specific_leaf_area
             Sum Sq  Df F value    Pr(>F)    
(Intercept)  372214   1 68.1828 1.081e-13 ***
Species_code 251804   7  6.5894 1.012e-06 ***
Position      14568   1  2.6686   0.10463    
Shoreplot     23015   1  4.2159   0.04194 *  
Residuals    753351 138                      
---
Signif. codes:  0 ‘***’ 0.001 ‘**’ 0.01 ‘*’ 0.05 ‘.’ 0.1 ‘ ’ 1
```
Finally, this is a test of the **interactive effects between shore/upland, high/low, and species**. Species is highly significant, as previously noted; shore versus non-shore is also statistically significant (P = 0.042, near bottom; shore trees have on average much lower SLA); while canopy position is not (P = 0.105).